### PR TITLE
DRUP-925: #ready allow br tag in site alert

### DIFF
--- a/www/sites/all/modules/custom/site_alert/site_alert.module
+++ b/www/sites/all/modules/custom/site_alert/site_alert.module
@@ -147,7 +147,7 @@ function site_alert_get_alert() {
       $output = '<div class=' .$level .'>';
       $output .= '<div class=text>';
 
-      $tags = array('a', 'em', 'strong');
+      $tags = array('a', 'br', 'em', 'strong');
       $output .= filter_xss($alert, $tags);
       $output .= '</div></div>';
 


### PR DESCRIPTION
I tested this locally and should work in `www-test` with minimal work.